### PR TITLE
Just prevent `TypeError: Cannot read property 'constructor' of undefined`

### DIFF
--- a/dist/angular-validation.js
+++ b/dist/angular-validation.js
@@ -778,7 +778,7 @@ angular.module('validation.directive', ['validation.provider']);
             }
           };
 
-          if (isValid.constructor === Object) isValid.then(setFocus);
+          if (isValid || isValid.constructor === Object) isValid.then(setFocus);
           else setFocus(isValid);
         });
 

--- a/dist/angular-validation.js
+++ b/dist/angular-validation.js
@@ -778,7 +778,7 @@ angular.module('validation.directive', ['validation.provider']);
             }
           };
 
-          if (isValid || isValid.constructor === Object) isValid.then(setFocus);
+          if (isValid && (isValid.constructor === Object)) isValid.then(setFocus);
           else setFocus(isValid);
         });
 


### PR DESCRIPTION
Just prevent `TypeError: Cannot read property 'constructor' of undefined`