### PR TITLE
#257 Fix for initialValidity set up

### DIFF
--- a/src/validator.directive.js
+++ b/src/validator.directive.js
@@ -239,9 +239,9 @@
         /**
          * Set initial validity to undefined if no boolean value is transmitted
          */
-        var initialValidity;
-        if (typeof scope.initialValidity === 'boolean') {
-          initialValidity = scope.initialValidity;
+        var initialValidity = void 0;
+        if (typeof attrs.initialValidity === 'boolean') {
+          initialValidity = attrs.initialValidity;
         }
 
         /**


### PR DESCRIPTION
Here is a fix for initialValidity set up from the scope instead of attrs